### PR TITLE
Add execution to the unit test tag

### DIFF
--- a/src/TestRunBuilder.ts
+++ b/src/TestRunBuilder.ts
@@ -89,6 +89,8 @@ export class TestRunBuilder {
       owner, priority, fileLocation, workItemIds, className,
     } = testDefinitionAdditionalInfo;
 
+    const executionId = testResult.$executionId;
+
     // add test definition
     const unitTest: UnitTestType = new UnitTestType({
       $id: testResult.$testId,
@@ -98,6 +100,7 @@ export class TestRunBuilder {
       Owners: owner ? {
         Owner: [{ $name: owner }],
       } : undefined,
+      Execution: executionId ? { $id: executionId } : undefined,
       WorkItemIDs: workItemIds
         ? { WorkItem: workItemIds.map((item) => ({ $id: item })) }
         : undefined,


### PR DESCRIPTION
Azure cloud test task looks for execution ID from the UnitTest to populate the owner, test results as well as other information together. But the current implementation does not have the execution tag under the UnitTest. Add it to the tag to make sure correct information is correctly populated and shown under Azure DevOps 